### PR TITLE
chore: use vim.bo.filetype to disable completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Typr
 
 A Neovim plugin for practice typing with a very beautiful dashboard.
- 
+
 ![typr](https://github.com/user-attachments/assets/4426d1c4-c4d3-4da7-987a-3b4c4395a4b5)
 ![typrstats](https://github.com/user-attachments/assets/b1653de3-05f3-4b90-b35e-9341eed8bf3e)
 ![typrstats vertical](https://github.com/user-attachments/assets/1ca824a0-5227-48c4-991c-f793cf62074a)
 
-# Install 
+# Install
 
 - Users which used typr before, delete your previous typrstats file.
 
@@ -24,6 +24,12 @@ A Neovim plugin for practice typing with a very beautiful dashboard.
 # Config
 
 https://github.com/nvzone/typr/blob/main/lua/typr/state.lua#L18
+
+## Disable completion
+
+The typr buffer has the filetype set to `typr`. Refer to your completion plugins documentation on
+how to disable it for that filetype which you can read using the buffer-scoped option
+`vim.bo.filetype`.
 
 # Mappings
 


### PR DESCRIPTION
Hi and thank you again for this beautiful plugin 🥳 

I am using completion plugin https://cmp.saghen.dev and wanted to turn it off. I then found that [typr buffer has the filetype set](https://github.com/nvzone/typr/blob/8904dc09ed4e4a4397fc3a4f2884f11e85d27c5d/lua/typr/init.lua#L82) to `typr`. This allows anyone to disable completion plugins using the `vim.bo.filetype` and whatever mechanism the completion plugin provides:

* for cmp https://github.com/hrsh7th/nvim-cmp/blob/main/doc/cmp.txt#L806-L811

* for blink https://cmp.saghen.dev/configuration/general.html

```lua
    ---@type blink.cmp.Config
    opts = {
      enabled = function()
        return not vim.tbl_contains({ "typr"}, vim.bo.filetype)
          and vim.bo.buftype ~= "prompt"
          and vim.b.completion ~= false
      end,
   }
```

Keeping the info generic in the readme should keep it fresh. I removed the `cmp` specific code as I think this should live in users config.
