### PR TITLE
fix: dont overwrite incorrect character

### DIFF
--- a/lua/typr/utils.lua
+++ b/lua/typr/utils.lua
@@ -124,7 +124,9 @@ M.gen_lines_diff = function(line, userline)
 
     local resultlen = #result
 
-    if expected ~= char and expected == " " then
+    if expected ~= char and char ~= " " then
+      expected = char
+    elseif expected ~= char and expected == " " then
       expected = "x"
     end
 


### PR DESCRIPTION
Hi siduck! Thanks for the great plugin.

I noticed that when an incorrect letter was typed, it would overwrite the expected character with the incorrect input character. 

Not sure if this is expected behaviour, but I saw on a comment on reddit that this is meant to be a MonkeyType like experience, I've updated it to display the expected character in red.

As to not break anything I've left the modified if statement as an `elseif` as I wasn't 100% sure what it was used for.

I've attached some gifs below to demonstrate the change

Before changes applied:
![before_changes](https://github.com/user-attachments/assets/0de81cfd-e047-4bfd-8302-28f61e3c1d6e)


After changes applied:
![after_changes](https://github.com/user-attachments/assets/925fbef5-f8d5-4d7f-b3e9-c90fb44c6b60)


