### PR TITLE
fix reading empty stats

### DIFF
--- a/lua/typr/stats/utils.lua
+++ b/lua/typr/stats/utils.lua
@@ -50,12 +50,12 @@ M.restore_stats = function()
   local path = state.config.stats_filepath
   local ok, stats = pcall(dofile, path)
 
-  if ok then
+  if ok and stats then
     state.data = vim.json.decode(stats)
   else
     local oldfile = vim.fn.stdpath "config" .. "/typrstats"
     local ok2, oldata = pcall(dofile, oldfile)
-    state.data = ok2 and vim.json.decode(oldata) or M.gen_default_stats()
+    state.data = ok2 and oldata and vim.json.decode(oldata) or M.gen_default_stats()
     M.save_str_tofile(state.data)
   end
 end


### PR DESCRIPTION
Hello, I'm not sure why but after a while the plugin couldnt read/restore the stats. 
I guess the stats file got corrupted or emptied on my side for whatever reason. 
So this fixed it
Really great plugin !