### PR TITLE
Background Transparency

### DIFF
--- a/lua/typr/init.lua
+++ b/lua/typr/init.lua
@@ -38,7 +38,12 @@ M.open = function()
     border = "none",
   })
 
-  vim.wo[dim_win].winblend = 20
+  if state.config.transparent_background then
+    vim.wo[dim_win].winblend = 100
+  else
+    vim.wo[dim_win].winblend = 20
+  end
+
 
   utils.gen_default_lines()
 

--- a/lua/typr/state.lua
+++ b/lua/typr/state.lua
@@ -30,6 +30,7 @@ local M = {
     random = false,
     phrases = nil, -- can be a table of strings
     insert_on_start = false,
+    transparent_background = false,
     stats_filepath = vim.fn.stdpath "data" .. "/typrstats",
     mappings = nil,
     -- or function(buf) end

--- a/lua/typr/stats/init.lua
+++ b/lua/typr/stats/init.lua
@@ -30,7 +30,11 @@ M.open = function()
     border = "none",
   })
 
-  vim.wo[dim_win].winblend = 20
+  if state.config.transparent_background then
+    vim.wo[dim_win].winblend = 100
+  else
+    vim.wo[dim_win].winblend = 20
+  end
 
   require("typr.stats.utils").init_volt()
   state.h = voltstate[state.statsbuf].h


### PR DESCRIPTION
I use transparency.nvim and have found the semi-opaque background of typr and typrstats to be a bit jarring. (Quite similar to what was mentioned in [this issue.]( https://github.com/nvzone/typr/issues/47))

To address this, I've introduced a new config option called background_transparency. It's a boolean that is false by default. When true, it assigns '100' to both winblend values instead of the usual 20, making the background fully transparent.

<img width="1924" height="1074" alt="image" src="https://github.com/user-attachments/assets/8af1e4d3-ca7b-4070-9d05-b60daaf6de4f" />

I absolutely love this project, so I wanted to see if there was a way to make it even better for transparency users like myself. 